### PR TITLE
Update tidyverse_verbs.qmd

### DIFF
--- a/tidyverse_verbs.qmd
+++ b/tidyverse_verbs.qmd
@@ -7,6 +7,7 @@ We saw in the previous chapter that we can use familiar `dplyr` verbs with data 
 Let's load the required libraries, add our data to a duckdb database, and then create references to each of these tables.
 
 ```{r, message=FALSE, warning=FALSE}
+install.packages("nycflights13")
 library(dplyr)
 library(dbplyr)
 library(tidyr)


### PR DESCRIPTION
For someone following along (as I'm doing), the line 
> copy_nycflights13(db)
will throw an error:
Error in find.package(package, lib.loc, verbose = verbose) : 
  there is no package called ‘nycflights13’